### PR TITLE
Add production release and build documentation workflow files

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -1,0 +1,88 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git Tag (Release) to validate and upload'
+        required: true
+        type: string
+
+jobs:
+  validate-release:
+    name: Validate Release Across Python Versions 🔍
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install wheel and build tools
+        run: python -m pip install --upgrade wheel build
+
+      - name: Install project dependencies
+        run: |
+          pip install -r ci/requirements.txt
+          pip install .
+
+      - name: Run tests
+        run: pytest tests --cov solt --cov-report term-missing -v
+
+      - name: Check code formatting
+        run: black --config=black.toml --check .
+
+      - name: Run flake8 linter
+        run: flake8
+
+  build-and-publish:
+    name: Build and Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: validate-release
+    environment:
+      name: pypi
+      url: https://pypi.org/project/solt/
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel build twine
+
+      - name: Build distributions
+        run: |
+          python -m build
+
+      - name: Validate built packages with twine
+        run: |
+          twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist/
+          verbose: true

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-release:
-    name: Validate Release Across Python Versions 🔍
+    name: Validate Release Across Python Versions
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -1,12 +1,8 @@
 name: Publish to PyPI
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Git Tag (Release) to validate and upload'
-        required: true
-        type: string
+  release:
+    types: [published]
 
 jobs:
   validate-release:
@@ -21,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -1,0 +1,41 @@
+# .github/workflows/update-docs.yml
+
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'doc/**'
+
+jobs:
+  build-deploy-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx
+          pip install .
+
+      - name: Build documentation
+        working-directory: doc
+        run: make html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/_build/html
+          publish_branch: gh-pages
+          force_orphan: true


### PR DESCRIPTION
Fixes: https://github.com/imedslab/solt/issues/89 and https://github.com/imedslab/solt/issues/90

This PR create two pipelines:
* one for publishing a new version to PyPi with two steps:
  * `validate-release`: validates the release for each of the following python versions: 3.9, 3.10, 3.11, 3.12 (similar to the ci pipeline)
  * `build-and-publish`: builds the project, validates the files using twine, and published the built files to PyPi
  The pipeline is triggered when a new release is created and the second step has to be approved by someone from the pypi env approvers list.
* one for publishing the docs to https://imedslab.github.io/solt/ whenever there's a change to /doc